### PR TITLE
ci: use GitHub only release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,5 +9,6 @@ on:
 
 jobs:
   default:
-    uses: Hapag-Lloyd/Workflow-Templates/.github/workflows/maven_release_callable.yml@c34ea75ff9e52d92a9433a19dd9fcd473bac2eee
+    # using a GitHub only release here. Use .github/update_workflows.sh to switch to a Maven release
+    uses: Hapag-Lloyd/Workflow-Templates/.github/workflows/default_release_callable.yml@c34ea75ff9e52d92a9433a19dd9fcd473bac2eee
     secrets: inherit


### PR DESCRIPTION
# Description

A Maven release does not work here as the `pom.xml` is incomplete and the release always fails. We don't want to push the template file to Maven.

A new repository using this template runs the `.github/update_workflows.sh` which copies the correct files.

# Verification

None

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
